### PR TITLE
Fix a bug where the plugin will not load

### DIFF
--- a/addons/qodot/src/nodes/qodot_map.gd
+++ b/addons/qodot/src/nodes/qodot_map.gd
@@ -19,7 +19,7 @@ var map_file := "" :
 		if map_file != new_map_file:
 			map_file = new_map_file
 var inverse_scale_factor := 16.0
-var entity_fgd := preload("res://addons/qodot/game_definitions/fgd/qodot_fgd.tres")
+var entity_fgd := load("res://addons/qodot/game_definitions/fgd/qodot_fgd.tres")
 var base_texture_dir := "res://textures"
 var texture_file_extensions := PackedStringArray(["png"])
 


### PR DESCRIPTION
Changed "preload" to "load" due to a bug where it would not recognize "Qodot_Map" in qodot_plugin.gd. This fixes the issue. @fire and I have tested it locally and it fixes the issue. The code is provided by fire. I am just making the pull request because I do not want to deal with this issue again. 